### PR TITLE
Finished `GetAvailableRecipes`

### DIFF
--- a/CIS560-RecipeManager/CIS560-RecipeManager/CIS560-RecipeManager.csproj
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/CIS560-RecipeManager.csproj
@@ -84,6 +84,7 @@
     <Compile Include="RecipeManager\uiRecipeDetailForm.Designer.cs">
       <DependentUpon>uiRecipeDetailForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Repository\Query\GetAvailableRecipes.cs" />
     <Compile Include="Repository\Query\ReadRecipe.cs" />
     <Compile Include="Repository\Query\ReadIngredient.cs" />
     <Compile Include="Repository\IngredientQuery.cs" />
@@ -199,6 +200,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <DependentUpon>RecipeDatabase.mdf</DependentUpon>
     </Content>
+    <Content Include="Sql\GetAvailableRecipes.sql" />
     <Content Include="Sql\SampleData\AddPantryItem.sql" />
     <Content Include="Sql\SampleData\AddRecipe.sql" />
   </ItemGroup>

--- a/CIS560-RecipeManager/CIS560-RecipeManager/HomeController.cs
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/HomeController.cs
@@ -25,8 +25,7 @@ namespace CIS560_RecipeManager
 
         public HomeController()
         {
-            new Query().ReadRecipe(2);
-
+            
             _queryStub = new QueryStub();
             _recipeInventory = new RecipeInventory();
             _pantry = new MyPantry();

--- a/CIS560-RecipeManager/CIS560-RecipeManager/Repository/IngredientQuery.cs
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/Repository/IngredientQuery.cs
@@ -58,11 +58,6 @@ namespace CIS560_RecipeManager.Repository
             throw new NotImplementedException();
         }
 
-        public IReadOnlyCollection<Recipe> GetAvailableRecipes()
-        {
-            throw new NotImplementedException();
-        }
-
         public ShoppingList GetShoppingList(ICollection<Recipe> recipes)
         {
             throw new NotImplementedException();

--- a/CIS560-RecipeManager/CIS560-RecipeManager/Repository/Query/GetAvailableRecipes.cs
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/Repository/Query/GetAvailableRecipes.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Transactions;
+using CIS560_RecipeManager.RecipeManager;
+
+namespace CIS560_RecipeManager.Repository
+{
+    public partial class Query : IQuery
+    {
+        public IReadOnlyCollection<Recipe> GetAvailableRecipes()
+        {
+            using (var connection = new SqlConnection(Properties.Settings.Default.RecipeDatabaseConnectionString))
+            {
+                using (var transaction = new TransactionScope())
+                {
+
+                    connection.Open();
+
+
+                    int id;
+                    String name;
+                    int quantity;
+                    string description;
+                    int categoryID;
+                    List<int> recipeIDs = new List<int>();
+
+                    using (var command = new SqlCommand(@"
+SELECT R.RecipeID
+FROM[dbo].[Recipes] R
+-- I would prefer for a way to check forall x.P(x) rather than not exists x.not p(x).
+WHERE NOT EXISTS
+   (
+      SELECT 1
+
+      FROM[dbo].RecipeIngredient RI
+
+        JOIN[dbo].PantryItem[PI] ON RI.PantryItemID = [PI].PantryItemID
+
+      WHERE R.RecipeID = RI.RecipeID
+
+        AND[PI].QuantityInPantry < RI.RecipeQuantity
+   )", connection))
+                    {
+
+                        var result = command.ExecuteReader();
+                        
+                        // I don't believe that checking for result.HasRows is needed in this use-case.
+                        while (result.Read())
+                        {
+                            id = result.GetFieldValue<int>(0);
+                            recipeIDs.Add(id);
+                        }
+                    }
+
+                    connection.Close();
+
+                    return recipeIDs.Select(i => ReadRecipe(i)).ToList();
+                }
+            }
+        }
+    }
+}

--- a/CIS560-RecipeManager/CIS560-RecipeManager/Repository/Query/ReadIngredient.cs
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/Repository/Query/ReadIngredient.cs
@@ -31,11 +31,11 @@ namespace CIS560_RecipeManager.Repository
                         //param.Direction = ParameterDirection.Output;
 
                         var result = command.ExecuteReader();
-                        Console.WriteLine("--------------------------------------------------------");
-                        Console.WriteLine(connection.Database);
-                        Console.WriteLine(result);
-                        Console.WriteLine(result?.GetType());
-                        Console.WriteLine("--------------------------------------------------------");
+                        //Console.WriteLine("--------------------------------------------------------");
+                        //Console.WriteLine(connection.Database);
+                        //Console.WriteLine(result);
+                        //Console.WriteLine(result?.GetType());
+                        //Console.WriteLine("--------------------------------------------------------");
 
                         int id;
                         String name;
@@ -50,8 +50,6 @@ namespace CIS560_RecipeManager.Repository
                             unit = result.GetFieldValue<String>(3);
 
                             ingredient = new Ingredient(id, name, unit);
-
-                            Console.WriteLine(ingredient);
                         }
                         else
                         {

--- a/CIS560-RecipeManager/CIS560-RecipeManager/Sql/GetAvailableRecipes.sql
+++ b/CIS560-RecipeManager/CIS560-RecipeManager/Sql/GetAvailableRecipes.sql
@@ -1,0 +1,11 @@
+﻿SELECT R.RecipeID
+FROM [dbo].[Recipes] R
+-- I would prefer for a way to check forall x. P(x) rather than not exists x. not p(x).
+WHERE NOT EXISTS
+   (
+      SELECT 1
+	  FROM [dbo].RecipeIngredient RI
+		JOIN [dbo].PantryItem [PI] ON RI.PantryItemID = [PI].PantryItemID
+	  WHERE R.RecipeID = RI.RecipeID
+		AND [PI].QuantityInPantry < RI.RecipeQuantity
+   )


### PR DESCRIPTION
Since the last pull request I finished the `GetAvailableRecipes` Method and removed extraneous print statements.

Notably, I use `Not Exists` and I would prefer to use a `ALL(predicate of subquery)` but, I didn't find any support for that in TSQL.

The actual query is

```sql
SELECT R.RecipeID
FROM [dbo].[Recipes] R
-- I would prefer for a way to check forall x. P(x) rather than not exists x. not p(x).
WHERE NOT EXISTS
   (
      SELECT 1
      FROM [dbo].RecipeIngredient RI
		JOIN [dbo].PantryItem [PI] ON RI.PantryItemID = [PI].PantryItemID
      WHERE R.RecipeID = RI.RecipeID
		AND [PI].QuantityInPantry < RI.RecipeQuantity
   )
```
Which works by selecting all recipe IDs that don't have any recipeIngredients that require an amount exceeding that in the pantry.
